### PR TITLE
Add documentation about activation of transmart-metacore-plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,11 @@
 transmart-metacore-plugin is a grails plugin to enable Metacore capabilities within TranSMART
+This plugin is not built separately; it is built together with the other plugins when
+transmartApp is built.
+
+To enable the transmart-metacore-plugin, edit the Config.groovy file (found in ~/grails/tranmartConfig directory.)
+
+At the end of the file, add a line:
+com.thomsonreuters.transmart.metacoreAnalyticsEnable=true
+
+or uncomment the line and change the value from 'false' to true.
+


### PR DESCRIPTION
Added documentation about build, activation, and configuration information about transmart-metacore-plugin.

I am attaching a document here in addtion.
[tranSMART metacore Plugin.docx](https://github.com/transmart/transmart-metacore-plugin/files/261971/tranSMART.metacore.Plugin.docx)
