### PR TITLE
Replaced call metacore-plugin from transmart to the plugin

### DIFF
--- a/TransmartMetacorePluginGrailsPlugin.groovy
+++ b/TransmartMetacorePluginGrailsPlugin.groovy
@@ -1,3 +1,5 @@
+import grails.util.Holders
+
 class TransmartMetacorePluginGrailsPlugin {
     // the plugin version
     def version = "1.2.2-SNAPSHOT"
@@ -48,7 +50,11 @@ Transmart MetaCore support
     }
 
     def doWithApplicationContext = { ctx ->
-        // TODO Implement post initialization spring config (optional)
+        def config = Holders.config
+        if (config.com.thomsonreuters.transmart.metacoreAnalyticsEnable) {
+            def extensionsRegistry = ctx.getBean('transmartExtensionsRegistry')
+            extensionsRegistry.registerAnalysisTabExtension("transmart-metacore-plugin", "/MetacoreEnrichment/loadScripts", 'loadMetaCoreEnrichment')
+        }
     }
 
     def onChange = { event ->


### PR DESCRIPTION
Removed hard code call transmart-metacore-plugin. Required dependency https://github.com/baroleg/transmart-metacore-plugin/tree/replaced_metacore_to_plugin
