### PR TITLE
Fixed if GENE_SYMBOL is empty throw Array Index Out Of Bounds Exception.

### DIFF
--- a/grails-app/controllers/com/thomsonreuters/lsps/transmart/MetacoreEnrichmentController.groovy
+++ b/grails-app/controllers/com/thomsonreuters/lsps/transmart/MetacoreEnrichmentController.groovy
@@ -61,14 +61,15 @@ class MetacoreEnrichmentController {
 		f.eachLine {
 			line ->
 			if (i > 0) {
-				def values = line.split("\t")
+				def values = line.split('\t',13) //If GENE_SYMBOL is empty need add limit to split or length line will be less 11
 				def z_score = 0
 				
 				try {
 					z_score = Double.parseDouble(values[7])
 				}
-				catch (e) {}
-				
+				catch (e) {
+					log.debug "Can not parse z_score ${values[7]}"
+				}
 				if (values[11] && Math.abs(z_score) >= threshold) geneList << values[11]
 			}
 			


### PR DESCRIPTION
If cell GENE_SYMBOL in mRNA.trans is empty then can't calculate result and show Array Index Out Of Bounds Exception in log. 
